### PR TITLE
[PKG-2497] mizani 0.9.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-upload_channels:
-  - sk_test
-channels:
-  - sk_test
-upload_without_merge: True

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_channels:
+  - sk_test
+channels:
+  - sk_test
+upload_without_merge: True

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - matplotlib-base >=3.5.0
     - pandas >=1.3.5
     - scipy >=1.5.0
-    - tzdata
+    - tzdata  # [win]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - wheel
   run:
     - python
-    - numpy>=1.19.0
+    - numpy >=1.19.0
     - backports.zoneinfo  # [py<39]
     - matplotlib-base >=3.5.0
     - pandas >=1.3.5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,65 +1,59 @@
 {% set name = "mizani" %}
 {% set version = "0.9.2" %}
-{% set bundle = "tar.gz" %}
-{% set hash = "1d481a4dc673caa9b7cfdc6505b9401f0e9a9f43434d748df0678a1a4017b0e2" %}
-{% set build = 0 %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.{{ bundle }}
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
-  sha256: {{ hash }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 1d481a4dc673caa9b7cfdc6505b9401f0e9a9f43434d748df0678a1a4017b0e2
 
 build:
-  number: {{ build }}
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+  skip: True  # [py<38]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
-    - python >=3.8.0
+    - python
     - pip
     - setuptools
     - setuptools_scm
-
+    - wheel
   run:
-    - python >=3.8.0
-    - numpy >=1.19.0
-    - scipy >=1.5.0
-    - pandas >=1.3.5
+    - python
+    - {{ pin_compatible('numpy') }}
+    - backports.zoneinfo  # [py<39]
     - matplotlib-base >=3.5.0
-    - backports.zoneinfo  # py<3.9 conda does not properly support environment markers
-    - tzdata  # os == windows
+    - pandas >=1.3.5
+    - scipy >=1.5.0
+    - tzdata  # [win]
 
 test:
-  requires:
-    - pip
-    - pytest
-    - pytest-cov
   imports:
     - mizani
     - mizani.external
     - mizani.tests
-  source_files:
-    - '*'
-  commands:
-    # The pip version can reported incorrectly if setuptools_scm isn't available
-    # at build time
-    - pip list | grep -i {{ name }} | grep {{ version }}
-    - pip check
-    - echo $PWD
-    - ls -larth
+  requires:
+    - pip
     - pytest
+    - pytest-cov
+  source_files:
+    - 'mizani/tests/*.py'
+  commands:
+    - pip check
+    - cd mizani && pytest tests -vv
 
 about:
   home: https://github.com/has2k1/mizani
   license_file: LICENSE
   license: BSD-3-Clause
   license_family: BSD
-  summary: Scales for Python
+  summary: A scales package for python
+  description: |
+    Mizani is a scales package for graphics. 
+    It is written in Python and is based on Hadley Wickham's Scales.
   dev_url: https://github.com/has2k1/mizani
   doc_url: https://mizani.readthedocs.io/en/latest/
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,6 +35,7 @@ test:
     - mizani
     - mizani.external
     - mizani.tests
+    - mizani.colors
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - matplotlib-base >=3.5.0
     - pandas >=1.3.5
     - scipy >=1.5.0
-    - tzdata  # [win]
+    - tzdata
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - wheel
   run:
     - python
-    - {{ pin_compatible('numpy') }}
+    - numpy>=1.19.0
     - backports.zoneinfo  # [py<39]
     - matplotlib-base >=3.5.0
     - pandas >=1.3.5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ test:
   source_files:
     - 'mizani/tests/*.py'
   commands:
-    - pip check
+    - pip check  # [not win]
     - cd mizani && pytest tests -vv
 
 about:


### PR DESCRIPTION
Changelog: https://github.com/has2k1/mizani/releases
License: https://github.com/has2k1/mizani/blob/v0.9.2/LICENSE
Requirements: https://github.com/has2k1/mizani/blob/v0.9.2/pyproject.toml

Actions:
1. Clean up the recipe:
- Remove unused jinja2 variables, just KISS
- Remove `noarch` python
- Skip `py<38`
- Add flags `--no-deps --no-build-isolation` to `script`
- Add missing `wheel` to `host`
- Fix `python` in `host` and `run`
2. Add selectors for `backports.zoneinfo`
3. Do not use the `[win]` selector for `tzdata` as it's not built for this platform however the compiled package can be used on `Windows` https://github.com/AnacondaRecipes/tzdata-feedstock/blob/07c7f5de102ca5bf9e793838170f26fadd0c3a6b/recipe/meta.yaml#L19
4. Fix `source_files`
5. Remove debug commands from `test/requires` and fix the `pytest` command
6. Update `summary`
7. Add `description`

Notes:
- `plotnine 0.12.1` requires `mizani >=0.9.0`, see https://github.com/has2k1/plotnine/blob/v0.12.1/pyproject.toml#L27