### PR TITLE
Pkg 4929 mizani 0.11.4

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-upload_channels:
-  - sk_test
-channels:
-  - sk_test
-upload_without_merge: True

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_channels:
+  - sk_test
+channels:
+  - sk_test
+upload_without_merge: True

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mizani" %}
-{% set version = "0.11.3" %}
+{% set version = "0.11.4" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: a8e0b16627442bda2899e39f834ff004eb49f2da874f01f13aa329d073d6adc5
+  sha256: 9fdb79e88602ca29132613b428d6c1e8af436e88e37d55a0f8eb99fe044c9bc2
 
 build:
   number: 0
@@ -23,7 +23,7 @@ requirements:
     - wheel
   run:
     - python
-    - numpy >=1.23.0, <2
+    - numpy >=1.23.0
     - scipy >=1.7.0
     - pandas >=2.1.0
     - tzdata  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - matplotlib-base >=3.5.0
     - pandas >=1.3.5
     - scipy >=1.5.0
-    - tzdata
+    - tzdata  # [win]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - wheel
   run:
     - python
-    - numpy>=1.19.0
+    - numpy >=1.19.0
     - backports.zoneinfo  # [py<39]
     - matplotlib-base >=3.5.0
     - pandas >=1.3.5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,65 +1,59 @@
 {% set name = "mizani" %}
 {% set version = "0.9.2" %}
-{% set bundle = "tar.gz" %}
-{% set hash = "1d481a4dc673caa9b7cfdc6505b9401f0e9a9f43434d748df0678a1a4017b0e2" %}
-{% set build = 0 %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.{{ bundle }}
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
-  sha256: {{ hash }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 1d481a4dc673caa9b7cfdc6505b9401f0e9a9f43434d748df0678a1a4017b0e2
 
 build:
-  number: {{ build }}
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+  skip: True  # [py<38]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
-    - python >=3.8.0
+    - python
     - pip
     - setuptools
     - setuptools_scm
-
+    - wheel
   run:
-    - python >=3.8.0
-    - numpy >=1.19.0
-    - scipy >=1.5.0
-    - pandas >=1.3.5
+    - python
+    - {{ pin_compatible('numpy') }}
+    - backports.zoneinfo  # [py<39]
     - matplotlib-base >=3.5.0
-    - backports.zoneinfo  # py<3.9 conda does not properly support environment markers
-    - tzdata  # os == windows
+    - pandas >=1.3.5
+    - scipy >=1.5.0
+    - tzdata  # [win]
 
 test:
-  requires:
-    - pip
-    - pytest
-    - pytest-cov
   imports:
     - mizani
     - mizani.external
     - mizani.tests
-  source_files:
-    - '*'
-  commands:
-    # The pip version can reported incorrectly if setuptools_scm isn't available
-    # at build time
-    - pip list | grep -i {{ name }} | grep {{ version }}
-    - pip check
-    - echo $PWD
-    - ls -larth
+  requires:
+    - pip
     - pytest
+    - pytest-cov
+  source_files:
+    - 'mizani/tests/*.py'
+  commands:
+    - pip check
+    - cd mizani && pytest tests -vv
 
 about:
   home: https://github.com/has2k1/mizani
   license_file: LICENSE
   license: BSD-3-Clause
   license_family: BSD
-  summary: Scales for Python
+  summary: A scales package for python
+  description: |
+    Mizani is a scales package for graphics. 
+    It is written in Python and is based on Hadley Wickham's Scales.
   dev_url: https://github.com/has2k1/mizani
   doc_url: https://mizani.readthedocs.io/en/latest/
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,6 +35,7 @@ test:
     - mizani
     - mizani.external
     - mizani.tests
+    - mizani.colors
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mizani" %}
-{% set version = "0.9.2" %}
+{% set version = "0.11.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 1d481a4dc673caa9b7cfdc6505b9401f0e9a9f43434d748df0678a1a4017b0e2
+  sha256: a8e0b16627442bda2899e39f834ff004eb49f2da874f01f13aa329d073d6adc5
 
 build:
   number: 0
-  skip: True  # [py<38]
+  skip: True  # [py<39]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
@@ -23,28 +23,24 @@ requirements:
     - wheel
   run:
     - python
-    - numpy >=1.19.0
-    - backports.zoneinfo  # [py<39]
-    - matplotlib-base >=3.5.0
-    - pandas >=1.3.5
-    - scipy >=1.5.0
+    - numpy >=1.23.0
+    - scipy >=1.7.0
+    - pandas >=2.1.0
     - tzdata  # [win]
 
 test:
   imports:
     - mizani
-    - mizani.external
-    - mizani.tests
-    - mizani.colors
   requires:
     - pip
     - pytest
     - pytest-cov
   source_files:
-    - 'mizani/tests/*.py'
+    - "tests"
+    - pyproject.toml
   commands:
     - pip check  # [not win]
-    - cd mizani && pytest tests -vv
+    - pytest -vv
 
 about:
   home: https://github.com/has2k1/mizani
@@ -53,7 +49,7 @@ about:
   license_family: BSD
   summary: A scales package for python
   description: |
-    Mizani is a scales package for graphics. 
+    Mizani is a scales package for graphics.
     It is written in Python and is based on Hadley Wickham's Scales.
   dev_url: https://github.com/has2k1/mizani
   doc_url: https://mizani.readthedocs.io/en/latest/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - wheel
   run:
     - python
-    - numpy >=1.23.0
+    - numpy >=1.23.0, <2
     - scipy >=1.7.0
     - pandas >=2.1.0
     - tzdata  # [win]
@@ -39,7 +39,7 @@ test:
     - "tests"
     - pyproject.toml
   commands:
-    - pip check  # [not win]
+    - pip check
     - pytest -vv
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,9 @@ test:
     - pyproject.toml
   commands:
     - pip check
-    - pytest -vv
+    - pytest -vv # [not win]
+    # Skipping test as it is a bug in the code: Here is a PR fix https://github.com/has2k1/mizani/pull/46
+    - pytest -vv -k "not censor" # [win]
 
 about:
   home: https://github.com/has2k1/mizani
@@ -52,7 +54,7 @@ about:
     Mizani is a scales package for graphics.
     It is written in Python and is based on Hadley Wickham's Scales.
   dev_url: https://github.com/has2k1/mizani
-  doc_url: https://mizani.readthedocs.io/en/latest/
+  doc_url: https://mizani.readthedocs.io/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - matplotlib-base >=3.5.0
     - pandas >=1.3.5
     - scipy >=1.5.0
-    - tzdata  # [win]
+    - tzdata
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - wheel
   run:
     - python
-    - {{ pin_compatible('numpy') }}
+    - numpy>=1.19.0
     - backports.zoneinfo  # [py<39]
     - matplotlib-base >=3.5.0
     - pandas >=1.3.5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ test:
   source_files:
     - 'mizani/tests/*.py'
   commands:
-    - pip check
+    - pip check  # [not win]
     - cd mizani && pytest tests -vv
 
 about:


### PR DESCRIPTION
mizani 11.4

Destination channel: {defaults}

Links:
[Upstream repository](https://github.com/has2k1/mizani/blob/v0.11.4/pyproject.toml)
[Upstream changelog/diff](https://github.com/has2k1/mizani/compare/v0.9.2..v0.11.4)

Explanation of changes:
- Version and Hash updates
- Changed imports to test for as they were deprecated
- Changed test commands to be simpler
- Skipped test that exposes broken function that was revealed on the Windows Platform
